### PR TITLE
fix filling of pointers

### DIFF
--- a/datafiller.go
+++ b/datafiller.go
@@ -168,6 +168,9 @@ func (self *Filler) recursiveSet(val reflect.Value) {
 			}
 			return
 		} else if val.Kind() == reflect.Ptr {
+			tp := val.Type().Elem()
+			nw := reflect.New(tp)
+			val.Set(nw)
 			self.recursiveSet(reflect.Indirect(val))
 			return
 		} else if val.Kind() == reflect.Map {

--- a/datafiller_test.go
+++ b/datafiller_test.go
@@ -107,6 +107,26 @@ func TestPointerTypes(t *testing.T) {
 
 }
 
+type PFF struct {
+	PFQ string
+}
+
+type PFE struct {
+	PFF *PFF
+}
+
+func TestPointerTypesFilling(t *testing.T) {
+	expectedOutput := PFF{}
+	Fill(&expectedOutput)
+	i := PFE{}
+
+	Fill(&i)
+
+	if i.PFF == nil || i.PFF.PFQ == "" || i.PFF.PFQ != expectedOutput.PFQ {
+		t.Errorf("Fill error: Pointer not filled: %v, want %v", i.PFF, expectedOutput)
+	}
+}
+
 func TestSimpleValues(t *testing.T) {
 	// var BoolV bool
 	var IntV int


### PR DESCRIPTION
My problem was a pointer field in a struct. Instead of filling the value under the pointer, a nil pointer was created.   
This code creates a new object of the type of the pointer and then fills it recursively. This object is then used as value.