### PR TITLE
Make play nice with https://github.com/guregu/null

### DIFF
--- a/datafiller.go
+++ b/datafiller.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Pallinder/go-randomdata"
+	randomdata "github.com/Pallinder/go-randomdata"
 )
 
 func init() {
@@ -112,6 +112,7 @@ func (self *Filler) recursiveSet(val reflect.Value) {
 		var fullPath string
 		fullPath = val.Type().PkgPath() + "." + val.Type().Name()
 		pkgVal, ok := packages[fullPath]
+
 		if ok {
 			val.Set(pkgVal)
 			return

--- a/datafiller.go
+++ b/datafiller.go
@@ -17,6 +17,10 @@ func init() {
 
 const (
 	taggedStructKey = "datafiller"
+	// for random string generation
+	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 )
 
 // Function Fill takes a pointer to variable of any type and fills the variable
@@ -151,7 +155,15 @@ func (self *Filler) recursiveSet(val reflect.Value) {
 			}
 			return
 		} else if val.Kind() == reflect.String {
-			val.SetString("test")
+			//generate random string with len 10
+			b := make([]byte, 10)
+			for i := 0; i < 10; {
+				if idx := int(rand.Int63() & letterIdxMask); idx < len(letterBytes) {
+					b[i] = letterBytes[idx]
+					i++
+				}
+			}
+			val.SetString(string(b))
 			return
 		} else if val.Kind() == reflect.Struct {
 			lngth := val.NumField()

--- a/datafiller.go
+++ b/datafiller.go
@@ -18,10 +18,22 @@ func init() {
 const (
 	taggedStructKey = "datafiller"
 	// for random string generation
-	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	letterIdxBits = 6                    // 6 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 )
+
+//generate random string with len 10
+func generateString() string {
+	b := make([]byte, 10)
+	for i := 0; i < 10; {
+		if idx := int(rand.Int63() & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i++
+		}
+	}
+	return string(b)
+}
 
 // Function Fill takes a pointer to variable of any type and fills the variable
 // by with sample data. It panics if the passed value is not a pointer.
@@ -157,14 +169,7 @@ func (self *Filler) recursiveSet(val reflect.Value) {
 			return
 		} else if val.Kind() == reflect.String {
 			//generate random string with len 10
-			b := make([]byte, 10)
-			for i := 0; i < 10; {
-				if idx := int(rand.Int63() & letterIdxMask); idx < len(letterBytes) {
-					b[i] = letterBytes[idx]
-					i++
-				}
-			}
-			val.SetString(string(b))
+			val.SetString(generateString())
 			return
 		} else if val.Kind() == reflect.Struct {
 			lngth := val.NumField()

--- a/datafiller.go
+++ b/datafiller.go
@@ -26,8 +26,10 @@ const (
 //generate random string with len 10
 func generateString() string {
 	b := make([]byte, 10)
+	randSeed := rand.New(rand.NewSource(time.Now().Unix() + rand.Int63n(100)))
+
 	for i := 0; i < 10; {
-		if idx := int(rand.Int63() & letterIdxMask); idx < len(letterBytes) {
+		if idx := int(randSeed.Int63() & letterIdxMask); idx < len(letterBytes) {
 			b[i] = letterBytes[idx]
 			i++
 		}

--- a/datafiller_test.go
+++ b/datafiller_test.go
@@ -116,14 +116,12 @@ type PFE struct {
 }
 
 func TestPointerTypesFilling(t *testing.T) {
-	expectedOutput := PFF{}
-	Fill(&expectedOutput)
 	i := PFE{}
 
 	Fill(&i)
 
-	if i.PFF == nil || i.PFF.PFQ == "" || i.PFF.PFQ != expectedOutput.PFQ {
-		t.Errorf("Fill error: Pointer not filled: %v, want %v", i.PFF, expectedOutput)
+	if i.PFF == nil || i.PFF.PFQ == "" {
+		t.Errorf("Fill error: Pointer not filled: %v", i.PFF)
 	}
 }
 

--- a/datafiller_test.go
+++ b/datafiller_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	null "gopkg.in/guregu/null.v3"
 )
 
 // Actual tests
@@ -81,6 +83,30 @@ func TestSimpleTypes(t *testing.T) {
 		zero := reflect.Zero(testValue.Type())
 		if reflect.DeepEqual(ifc, zero.Interface()) {
 			t.Errorf("Changed value is zero-value (type: %v): value %v, do not want %v", testValue.Type(), zero.Interface(), ifc)
+		}
+	}
+}
+
+type PackageTest struct {
+	NullInt  null.Int
+	NullStr  null.String
+	NullBool null.Bool
+}
+
+func TestPackageTypes(t *testing.T) {
+	var p = PackageTest{}
+
+	Fill(&p)
+
+	vals := reflect.ValueOf(p)
+
+	for i := 0; i < vals.NumField(); i++ {
+		field := vals.Field(i).Interface()
+
+		if nullInt, ok := field.(null.Int); ok {
+			if !nullInt.Valid {
+				t.Fatalf("gopkg.in/guregu/null.Int.Valid is not true")
+			}
 		}
 	}
 }

--- a/packages.go
+++ b/packages.go
@@ -11,7 +11,7 @@ import (
 var packages = make(map[string]reflect.Value)
 
 func packagesInit() {
-	randSeed := rand.New(rand.NewSource(-1))
+	randSeed := rand.New(rand.NewSource(time.Now().Unix() + rand.Int63n(100)))
 	packages["time.Time"] = reflect.ValueOf(time.Unix(rand.Int63n(2000000000), 0))
 	// guregu/null structs have Valid field that is a bool.
 	// this field was occasionally randomly set to false, meaning whatever value was passsed

--- a/packages.go
+++ b/packages.go
@@ -4,10 +4,25 @@ import (
 	"math/rand"
 	"reflect"
 	"time"
+
+	null "gopkg.in/guregu/null.v3"
 )
 
 var packages = make(map[string]reflect.Value)
 
 func packagesInit() {
+	randSeed := rand.New(rand.NewSource(-1))
 	packages["time.Time"] = reflect.ValueOf(time.Unix(rand.Int63n(2000000000), 0))
+	// guregu/null structs have Valid field that is a bool.
+	// this field was occasionally randomly set to false, meaning whatever value was passsed
+	// would be interpreted as null. Always want some value, so always set valid = true for null packages
+	packages["null.String"] = reflect.ValueOf(null.NewString("test", true))
+	packages["null.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
+	if randSeed.Int63n(2) == 0 {
+		packages["null.Bool"] = reflect.ValueOf(null.NewBool(false, true))
+	} else {
+		packages["null.Bool"] = reflect.ValueOf(null.NewBool(true, true))
+	}
+	packages["null.Float"] = reflect.ValueOf(null.NewFloat(float64(randSeed.Float32()), true))
+	packages["null.Time"] = reflect.ValueOf(null.NewTime(time.Unix(rand.Int63n(2000000000), 0), true))
 }

--- a/packages.go
+++ b/packages.go
@@ -16,7 +16,7 @@ func packagesInit() {
 	// guregu/null structs have Valid field that is a bool.
 	// this field was occasionally randomly set to false, meaning whatever value was passsed
 	// would be interpreted as null. Always want some value, so always set valid = true for null packages
-	packages["gopkg.in/guregu/null.v3.String"] = reflect.ValueOf(null.NewString("test", true))
+	packages["gopkg.in/guregu/null.v3.String"] = reflect.ValueOf(null.NewString(generateString(), true))
 	packages["gopkg.in/guregu/null.v3.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
 	if randSeed.Int63n(2) == 0 {
 		packages["gopkg.in/guregu/null.v3.Bool"] = reflect.ValueOf(null.NewBool(false, true))

--- a/packages.go
+++ b/packages.go
@@ -16,13 +16,13 @@ func packagesInit() {
 	// guregu/null structs have Valid field that is a bool.
 	// this field was occasionally randomly set to false, meaning whatever value was passsed
 	// would be interpreted as null. Always want some value, so always set valid = true for null packages
-	packages["gopkg.in/guregu/null.String"] = reflect.ValueOf(null.NewString("test", true))
-	packages["gopkg.in/guregu/null.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
+	packages["gopkg.in/guregu/null.v3.String"] = reflect.ValueOf(null.NewString("test", true))
+	packages["gopkg.in/guregu/null.v3.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
 	if randSeed.Int63n(2) == 0 {
-		packages["gopkg.in/guregu/null.Bool"] = reflect.ValueOf(null.NewBool(false, true))
+		packages["gopkg.in/guregu/null.v3.Bool"] = reflect.ValueOf(null.NewBool(false, true))
 	} else {
-		packages["gopkg.in/guregu/null.Bool"] = reflect.ValueOf(null.NewBool(true, true))
+		packages["gopkg.in/guregu/null.v3.Bool"] = reflect.ValueOf(null.NewBool(true, true))
 	}
-	packages["gopkg.in/guregu/null.Float"] = reflect.ValueOf(null.NewFloat(float64(randSeed.Float32()), true))
-	packages["gopkg.in/guregu/null.Time"] = reflect.ValueOf(null.NewTime(time.Unix(rand.Int63n(2000000000), 0), true))
+	packages["gopkg.in/guregu/null.v3.Float"] = reflect.ValueOf(null.NewFloat(float64(randSeed.Float32()), true))
+	packages["gopkg.in/guregu/null.v3.Time"] = reflect.ValueOf(null.NewTime(time.Unix(rand.Int63n(2000000000), 0), true))
 }

--- a/packages.go
+++ b/packages.go
@@ -16,13 +16,13 @@ func packagesInit() {
 	// guregu/null structs have Valid field that is a bool.
 	// this field was occasionally randomly set to false, meaning whatever value was passsed
 	// would be interpreted as null. Always want some value, so always set valid = true for null packages
-	packages["null.String"] = reflect.ValueOf(null.NewString("test", true))
-	packages["null.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
+	packages["gopkg.in/guregu/null.String"] = reflect.ValueOf(null.NewString("test", true))
+	packages["gopkg.in/guregu/null.Int"] = reflect.ValueOf(null.NewInt(rand.Int63n(100), true))
 	if randSeed.Int63n(2) == 0 {
-		packages["null.Bool"] = reflect.ValueOf(null.NewBool(false, true))
+		packages["gopkg.in/guregu/null.Bool"] = reflect.ValueOf(null.NewBool(false, true))
 	} else {
-		packages["null.Bool"] = reflect.ValueOf(null.NewBool(true, true))
+		packages["gopkg.in/guregu/null.Bool"] = reflect.ValueOf(null.NewBool(true, true))
 	}
-	packages["null.Float"] = reflect.ValueOf(null.NewFloat(float64(randSeed.Float32()), true))
-	packages["null.Time"] = reflect.ValueOf(null.NewTime(time.Unix(rand.Int63n(2000000000), 0), true))
+	packages["gopkg.in/guregu/null.Float"] = reflect.ValueOf(null.NewFloat(float64(randSeed.Float32()), true))
+	packages["gopkg.in/guregu/null.Time"] = reflect.ValueOf(null.NewTime(time.Unix(rand.Int63n(2000000000), 0), true))
 }


### PR DESCRIPTION
the Null* structs all contain a boolean field `Valid`. This was getting filled randomly, which resulted in these fields being null when marshaled to JSON / db queries. 

Always set `Valid: true` for `gopkg.in/guregu/null.v3.*` packages